### PR TITLE
Use update instead of update_attributes

### DIFF
--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -21,7 +21,7 @@ describe Article do
     before do
       @article = Article.create!(title: 'Original Title')
       @article2 = Article.find(@article.id)
-      @article2.update_attributes(title: 'New Title')
+      @article2.update(title: 'New Title')
     end
 
     it "should reflect the change when the record is reloaded" do


### PR DESCRIPTION
`update_attributes` was deprecated in Rails 6.0 and recently removed in Rails 6.1. This commit fixes the test suite while running against Rails 6.1.x.

Note that `update` method was introduced as an alias since Rails 4.0.0. Since this gem is tested against Active Record 5.2+, I think it's OK to use `update` here.

For more details:
- https://blog.saeloun.com/2019/04/15/rails-6-deprecates-update-attributes.html
- https://github.com/rails/rails/pull/31998
- https://github.com/rails/rails/pull/8705