### PR TITLE
Use on_load hook for integration with ActiveRecord

### DIFF
--- a/lib/normalizr/integrations/active_record.rb
+++ b/lib/normalizr/integrations/active_record.rb
@@ -1,1 +1,3 @@
-ActiveRecord::Base.send(:include, Normalizr::Concern)
+ActiveSupport.on_load(:active_record) do
+  include Normalizr::Concern
+end


### PR DESCRIPTION
Calling `ActiveRecord::Base` directly will cause Active Record to load before the application has been initialized. This causes an unexpected behavior as users will not be able to override any settings using `config.active_record.*`, as those settings already get copied to `ActiveRecord::Base` when it got loaded.

Current behavior:

- Requiring this gem
- Active Record got loaded
- Settings from `config.active_record` got copied to `ActiveRecord::Base`
- Initializer files got loaded

After this change:

- Requiring this gem
- Initializer files got loaded
- Active Record got loaded
- Settings from `config.active_record` got copied to `ActiveRecord::Base`

More detail: https://guides.rubyonrails.org/engines.html#avoid-loading-rails-frameworks

Please note that the test suite on this branch will fail until https://github.com/dmeremyanin/normalizr/pull/11 is merged in.