### PR TITLE
fixing issue with locale accessors in Mobility

### DIFF
--- a/lib/normalizr/concern.rb
+++ b/lib/normalizr/concern.rb
@@ -20,8 +20,7 @@ module Normalizr
                 value = Normalizr.normalize(value, *options.before)
                 value = Normalizr.normalize(value, *options.after) if options.after.any?
               end
-
-              super(value, *method_args)
+              super(value, **method_args.reduce({}, :merge))
             end
           end
         }


### PR DESCRIPTION
I realized that we were still getting an error on assignment; the method arguments have to be converted to a hash and double splatted for mobility to accept it.  This makes it compatible with the locale_accessor https://github.com/shioyama/mobility/blob/master/lib/mobility/plugins/locale_accessors.rb

